### PR TITLE
Fix Buffer undefined reference error

### DIFF
--- a/modules/io/src/common/loaders.js
+++ b/modules/io/src/common/loaders.js
@@ -39,7 +39,11 @@ export function getDataContainer(data) {
     return null;
   }
 
-  if (data instanceof Buffer || data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+  if (
+    (typeof Buffer !== 'undefined' && data instanceof Buffer) ||
+    data instanceof ArrayBuffer ||
+    ArrayBuffer.isView(data)
+  ) {
     return 'binary';
   }
 
@@ -329,7 +333,7 @@ function isJSONStringTypeArray(arr) {
 
   // Buffer.slice() does not make a copy, but we need one since
   // we call reverse()
-  if (lastChars instanceof Buffer) {
+  if (typeof Buffer !== 'undefined' && lastChars instanceof Buffer) {
     lastChars = Buffer.from(lastChars);
   }
 

--- a/modules/io/src/common/xviz-data.js
+++ b/modules/io/src/common/xviz-data.js
@@ -100,20 +100,20 @@ export class XVIZData {
     let data = this._data;
     switch (this._dataFormat) {
       case XVIZ_FORMAT.BINARY_GLB:
-        if (data instanceof Buffer) {
+        if (typeof Buffer !== 'undefined' && data instanceof Buffer) {
           data = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
         }
         msg = parseBinaryXVIZ(data);
         break;
       case XVIZ_FORMAT.BINARY_PBE:
-        if (data instanceof Buffer) {
+        if (typeof Buffer !== 'undefined' && data instanceof Buffer) {
           data = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
         }
         msg = parseBinaryXVIZ(data, this._opts);
         break;
       case XVIZ_FORMAT.JSON_BUFFER:
         let jsonString = null;
-        if (data instanceof Buffer) {
+        if (typeof Buffer !== 'undefined' && data instanceof Buffer) {
           // Default to utf8 encoding
           jsonString = data.toString();
         } else if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
@@ -154,7 +154,7 @@ export class XVIZData {
     let data = this._data;
     switch (getDataContainer(data)) {
       case 'binary':
-        if (data instanceof Buffer) {
+        if (typeof Buffer !== 'undefined' && data instanceof Buffer) {
           data = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
         }
 


### PR DESCRIPTION
`instanceof Buffer` throws error on browser as `instanceof undefined` is a reference error. 

This problem is does not show up previously as Webpack injects a polyfill for `Buffer`. However other build tools like Vite or Rollup does not polyfill `Buffer` so throwing an uncaught error.