### PR TITLE
Freeze dependencies in requirements.txt

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
-easydict
-protobuf
-numpy
-websockets
-pytest
+easydict==1.9
+protobuf==3.20.1
+numpy==1.23.2
+websockets==10.3
+pytest==7.1.3


### PR DESCRIPTION
I had to install an old version of `protobuf` to be able to serve example. The latest version (4.21.5) does not work and suggests to downgrade to 3.20.x to be able to run. I thought freezing dependencies versions would be a good choice.